### PR TITLE
Added base logic to transition to a user-specified screen.

### DIFF
--- a/src/main/kotlin/com/thain/duo/PostureProcessorService.kt
+++ b/src/main/kotlin/com/thain/duo/PostureProcessorService.kt
@@ -751,6 +751,7 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
         - If you're transitioning from single screen to a dual screen posture, allow processing.
     */
     private fun staticallyTransformPosture(setRight: Boolean, isRotationLocked: Boolean, newPosture: Posture ){
+        Log.d(TAG, "Attempting a static posture transform, setRight: ${setRight}");
         currentPosture?.let {
             // Change if either the rot or posture has changed.
             if (it.posture != newPosture.posture || it.rotation.value != newPosture.rotation.value) {
@@ -782,6 +783,7 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
                             
                             //If not, provide an equivalent and overwrite the newPosture.
                             if(!isNewPostureMatchingLock){
+                                Log.d(TAG, "Converting ${newPosture.posture} to right-sided variant");
                                 newPosture.posture = getEquivalentPostureForSingleScreen(true, newPosture.posture)
                             }
 
@@ -789,10 +791,11 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
                         }
                         else{
                             // Check if the posture is matching the locked posture setting
-                            isNewPostureMatchingLock = isRightSidedPostures(newPosture.posture)
+                            isNewPostureMatchingLock = isLeftSidedPostures(newPosture.posture)
 
                             //If not, provide an equivalent and overwrite the newPosture.
                             if(!isNewPostureMatchingLock){
+                                Log.d(TAG, "Converting ${newPosture.posture} to left-sided variant");
                                 newPosture.posture = getEquivalentPostureForSingleScreen(false, newPosture.posture)
                             }
 

--- a/src/main/kotlin/com/thain/duo/PostureProcessorService.kt
+++ b/src/main/kotlin/com/thain/duo/PostureProcessorService.kt
@@ -863,9 +863,9 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
                     postureLockVal = PostureLockSetting.Dynamic
                 }
                 when (postureLockVal) {
-                    PostureLockSetting.Dynamic -> dynamicallyTransformPosture()
-                    PostureLockSetting.Right -> staticallyTransformPosture(true)
-                    PostureLockSetting.Left -> staticallyTransformPosture(false)
+                    PostureLockSetting.Dynamic -> dynamicallyTransformPosture(isRotationLocked, newPosture)
+                    PostureLockSetting.Right -> staticallyTransformPosture(true, isRotationLocked, newPosture)
+                    PostureLockSetting.Left -> staticallyTransformPosture(false, isRotationLocked, newPosture)
                 }
             }
 


### PR DESCRIPTION
This addition attempts to add logic to only target showing data onto a screen if it matches the user's specified target through settings. 

This should also mitigate some touch issues due to the rotation setting the opposite screen on when the user accidentally triggers the screen switch.

Retains the original logic as a separate "Dynamic" option that can still be triggered. This should be set as default. 

System Properties have not been setup in the GSI, and as a result this will not work until the system properties have been setup and correctly interface with the value being set in `onCreate()` and `processPosture()`.

Also adds helper functions to determine if a posture is Right, Left or a Dual Screen Posture. 

Improvements to this functionality would be greatly appreciated, as I do find myself accidentally changing screens without intention.

NOTE: Unfortunately I cannot test this easily right now as I have not setup the env properly, this may not work and may need some further tweaks to get working.