### PR TITLE
Pen charge Interface to lib file

### DIFF
--- a/src/main/kotlin/com/thain/duo/MSPenCharger.kt
+++ b/src/main/kotlin/com/thain/duo/MSPenCharger.kt
@@ -1,0 +1,15 @@
+package com.thain.duo
+
+// This needs to be here, as the Native functions 
+// refer to the package name as well! 
+// Will move this into pencharger when we change the function names on the native files.
+public class MSPenCharger {
+    companion object {
+        init {
+            System.loadLibrary("ms_pen_charger")
+        }
+    }
+
+    public external fun readSysfs(): String
+    public external fun writeSysfs(value: String)
+}

--- a/src/main/kotlin/com/thain/duo/WirelessChargingBroadcastReceiver.kt
+++ b/src/main/kotlin/com/thain/duo/WirelessChargingBroadcastReceiver.kt
@@ -5,22 +5,27 @@ import android.content.Intent
 import android.content.Context
 import android.os.SystemProperties
 import android.util.Log
-import android.widget.Toast
-import java.io.FileOutputStream
-import java.io.DataOutputStream
+import com.thain.duo.pencharger.PenChargerInterface
+import com.thain.duo.pencharger.PenChargerInterface.PowerState
 
 public class WirelessChargingBroadcastReceiver : BroadcastReceiver() {
     private var isDuo2: Boolean = false
 
     companion object {
         const val TAG = "WIRELESS PEN CHARGING"
-        const val penChargerFile = "/sys/devices/platform/soc/soc:surface_util/ms_pen_charger/ms_pen_charger"
     }
 
-    override fun onReceive(context: Context, intent: Intent){
+    override fun onReceive(context: Context, intent: Intent){        
         val action: String? = intent.getAction()
         isDuo2 = SystemProperties.get("ro.hardware", "N/A") == "surfaceduo2"
         
+
+        //Exit early if duo2.
+        if(!isDuo2){
+            Log.d(TAG, "Disallowed from running this action, not a Duo2")
+            return
+        }
+
         // 0 is OFF, 1 is ON for system properties!
         val chargingValue = SystemProperties.get("persist.sys.phh.duo.wireless_pen_charging", "0")
         
@@ -30,29 +35,17 @@ public class WirelessChargingBroadcastReceiver : BroadcastReceiver() {
                 Write 0 (ON) or 1 (OFF) into the specified file in duo2! Yes, this is
                 different to the charging value set from sys props.
             */ 
+            val penChargerInterface = PenChargerInterface()
             var valueToWrite: String = "1" // default OFF
 
             if(chargingValue.equals("1")){
                 valueToWrite = "0"
             }
-            
-            try {
-                // This doesn't work, we will need some sort of HAL to interface with this file.
-                // FileOutputStream(penChargerFile, false).use { fos ->
-                //     DataOutputStream(fos).use { dos ->
-                //         dos.writeBytes(valueToWrite)
-                //         Log.d(TAG, "Set pen charger to state ${valueToWrite}")
-                //     }
-                // }
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
-            return
-        }
 
-        if(!isDuo2){
-            Log.d(TAG, "Disallowed from running this action, not a Duo2")
-            return
+            val powerStateToWrite : PowerState = PowerState.fromString(valueToWrite)
+            
+            //Write and let the interface handle it.
+            penChargerInterface.SetPowerState(powerStateToWrite)
         }
     }
 } 

--- a/src/main/kotlin/com/thain/duo/pencharger/PenChargerInterface.kt
+++ b/src/main/kotlin/com/thain/duo/pencharger/PenChargerInterface.kt
@@ -1,0 +1,53 @@
+package com.thain.duo.pencharger
+
+import com.thain.duo.MSPenCharger
+import android.util.Log
+
+public class PenChargerInterface {
+    private var msPenCharger : MSPenCharger? = null
+    
+    public enum class PowerState(val value: Int) {
+        POWER_ON(0),
+        POWER_OFF(1);
+        
+        companion object {
+            fun fromInt(incomingValue: Int) = PowerState.values().first { it.value == incomingValue }
+            fun fromString(incomingValue: String?) = PowerState.values().first { it.value.equals(incomingValue?.toInt())}
+        }
+    }
+
+    companion object {
+        const val TAG = "WIRELESS PEN CHARGING"
+    }
+
+    constructor() {
+        msPenCharger = MSPenCharger()
+    }
+
+    /*
+        Read state, if it's different from incoming state, then write.
+    */
+    public fun SetPowerState(state: PowerState){
+        val currentPowerState : PowerState = GetPowerState()
+        try{
+            if(currentPowerState != state){
+                msPenCharger?.writeSysfs(state.value.toString())
+                Log.d(TAG, "Set power state to ${state} through pencharger interface.")
+            }
+            else{
+                Log.d(TAG, "Skipping write because values are the same.")
+            }
+        } catch (e: Exception){
+            e.printStackTrace()
+        }
+    }
+
+    public fun GetPowerState() : PowerState{
+        try{        
+            return PowerState.fromString(msPenCharger?.readSysfs())            
+        } catch (e : Exception){
+            e.printStackTrace()
+            return PowerState.POWER_OFF //Default value if unknown.
+        }
+    }
+}


### PR DESCRIPTION
Adds interface to library, should only write when values have changed. Defaults to power off.

I have left the MSPenCharger class in the com.thain.duo package as the native function calls require the package name to match. I will change it later when I have the time.