### PR TITLE
Add different layout and animation for peek mode

### DIFF
--- a/src/main/kotlin/com/thain/duo/PostureProcessorService.kt
+++ b/src/main/kotlin/com/thain/duo/PostureProcessorService.kt
@@ -407,40 +407,40 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
 
     private fun processPosture(newPosture: Posture) {
 
-    when (newPosture.posture) {
-        PSValue.Book,
-        PSValue.Palette,
-        PSValue.PeekLeft,
-        PSValue.PeekRight -> {
-            DeviceStateManagerGlobal.getInstance()?.requestState(
-                DeviceStateRequest.newBuilder(DeviceState.HALF_OPEN.value).build(),
-                null,
-                null
-            )
+        when (newPosture.posture) {
+            PSValue.Book,
+            PSValue.Palette,
+            PSValue.PeekLeft,
+            PSValue.PeekRight -> {
+                DeviceStateManagerGlobal.getInstance()?.requestState(
+                    DeviceStateRequest.newBuilder(DeviceState.HALF_OPEN.value).build(),
+                    null,
+                    null
+                )
+            }
+            PSValue.FlatDualP,
+            PSValue.FlatDualL -> {
+                DeviceStateManagerGlobal.getInstance()?.requestState(
+                    DeviceStateRequest.newBuilder(DeviceState.FLAT.value).build(),
+                    null,
+                    null
+                )
+            }
+            PSValue.Closed -> {
+                DeviceStateManagerGlobal.getInstance()?.requestState(
+                    DeviceStateRequest.newBuilder(DeviceState.CLOSED.value).build(),
+                    null,
+                    null
+                )
+            }
+            else -> {
+                DeviceStateManagerGlobal.getInstance()?.requestState(
+                    DeviceStateRequest.newBuilder(DeviceState.FOLDED.value).build(),
+                    null,
+                    null
+                )
+            }
         }
-        PSValue.FlatDualP,
-        PSValue.FlatDualL -> {
-            DeviceStateManagerGlobal.getInstance()?.requestState(
-                DeviceStateRequest.newBuilder(DeviceState.FLAT.value).build(),
-                null,
-                null
-            )
-        }
-        PSValue.Closed -> {
-            DeviceStateManagerGlobal.getInstance()?.requestState(
-                DeviceStateRequest.newBuilder(DeviceState.CLOSED.value).build(),
-                null,
-                null
-            )
-        }
-        else -> {
-            DeviceStateManagerGlobal.getInstance()?.requestState(
-                DeviceStateRequest.newBuilder(DeviceState.FOLDED.value).build(),
-                null,
-                null
-            )
-        }
-    }
 
         var pt = postureType(newPosture.posture)
         if (pt != 4 || pt != 5) {
@@ -448,35 +448,44 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
         }
         when (pt) {
             0 -> {
-                systemWm?.clearForcedDisplaySize(DEFAULT_DISPLAY)
-                displayManager?.setDisplayOffsets(DEFAULT_DISPLAY, 0, 0)
-                setComposition(2)
-                restartLauncher(this, true)
+                // Should only restart the launcher if the composition has changed.
+                if (currentDisplayComposition != 2){
+                    systemWm?.clearForcedDisplaySize(DEFAULT_DISPLAY)
+                    displayManager?.setDisplayOffsets(DEFAULT_DISPLAY, 0, 0)
+                    setComposition(2)
+                    restartLauncher(this, true)
+                }
             }
             1 -> {
-                displayManager?.setDisplayOffsets(DEFAULT_DISPLAY, -PANEL_OFFSET, 0)
-                systemWm?.setForcedDisplaySize(DEFAULT_DISPLAY, PANEL_X, PANEL_Y)
-                setComposition(0)
-                restartLauncher(this, false)
+                if(currentDisplayComposition != 0){
+                    displayManager?.setDisplayOffsets(DEFAULT_DISPLAY, -PANEL_OFFSET, 0)
+                    systemWm?.setForcedDisplaySize(DEFAULT_DISPLAY, PANEL_X, PANEL_Y)
+                    setComposition(0)
+                    restartLauncher(this, false)
+                }
             }
             2 -> {
-                displayManager?.setDisplayOffsets(DEFAULT_DISPLAY, PANEL_OFFSET, 0)
-                systemWm?.setForcedDisplaySize(DEFAULT_DISPLAY, PANEL_X, PANEL_Y)
-                setComposition(1)
-                restartLauncher(this, false)      
+                if(currentDisplayComposition != 1){
+                    displayManager?.setDisplayOffsets(DEFAULT_DISPLAY, PANEL_OFFSET, 0)
+                    systemWm?.setForcedDisplaySize(DEFAULT_DISPLAY, PANEL_X, PANEL_Y)
+                    setComposition(1)
+                    restartLauncher(this, false)
+                }      
             }
             3 -> {
                 systemWm?.clearForcedDisplaySize(DEFAULT_DISPLAY)
                 displayManager?.setDisplayOffsets(DEFAULT_DISPLAY, 0, 0)
                 setComposition(2)
             }
+
+            //The overlay refuses to show on these ones on Duo2. Forcing Dual Display.
             4 -> {
-                setComposition(0)
-                if (isPeakMode) peakModeOverlay.showOverlay(true)
+                setComposition(2)
+                if (isPeakMode) peakModeOverlay.showOverlay()
             }
             5 -> {
-                setComposition(1)
-                if (isPeakMode) peakModeOverlay.showOverlay(false)
+                setComposition(2)
+                if (isPeakMode) peakModeOverlay.showOverlay()
             }
             else -> {
                 Log.d(TAG, "Unhandled posture");

--- a/src/main/res/layout/peak_mode_overlay.xml
+++ b/src/main/res/layout/peak_mode_overlay.xml
@@ -1,17 +1,80 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#000000"
+    android:background="#AA000000"
     android:padding="-50dp">
     <!-- Left clock rotated 90 degrees -->
+    <View
+        android:id="@+id/battery_background"
+        android:layout_width="match_parent"
+        android:background="@drawable/expandable_square"
+        android:layout_alignParentBottom="true"
+        android:layout_height="1dp"/>
+
+    <View
+        android:layout_width="500dp"
+        android:layout_height="match_parent"
+        android:layout_alignParentLeft="true"
+        android:layout_marginLeft="25dp"
+        android:background="#000000" />
+
+    <View
+        android:layout_width="500dp"
+        android:layout_height="match_parent"
+        android:layout_marginRight="25dp"
+        android:layout_alignParentRight="true"
+        android:background="#000000" />
+
     <TextView
-        android:id="@+id/clock"
+        android:id="@+id/left_clock"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:textSize="60sp"
         android:textColor="#FFFFFF"
         android:rotation="90"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
         android:layout_centerVertical="true"
-        android:layout_marginLeft="-50dp" />
+        android:layout_marginLeft="0dp"
+        android:gravity="center_vertical"/>
+    <TextView
+        android:id="@+id/left_battery"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:textSize="30sp"
+        android:textColor="#FFFFFF"
+        android:rotation="90"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:layout_centerVertical="true"
+        android:layout_marginLeft="0dp"
+        android:gravity="center_vertical"/>
+
+
+    <TextView
+        android:id="@+id/right_clock"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:textSize="60sp"
+        android:textColor="#FFFFFF"
+        android:rotation="270"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentTop="true"
+        android:layout_centerVertical="true"
+        android:layout_marginRight="0dp"
+        android:gravity="center_vertical"/>
+
+    <TextView
+        android:id="@+id/right_battery"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:textSize="30sp"
+        android:textColor="#FFFFFF"
+        android:rotation="270"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentTop="true"
+        android:layout_centerVertical="true"
+        android:layout_marginRight="0dp"
+        android:gravity="center_vertical"/>
 
 </RelativeLayout>


### PR DESCRIPTION
#Modified the layout to use animations and add more information when in peak mode.

- Attempting to fix a bug where Duo2 doesn't see the overlay, reverting back to old variant of overlay which spans both screens.
- Adds an animation when the overlay is accessed. The green bar goes up to a percentage of the screen height based on current battery percent.
- Attempting to fix a bug where the Duo2 (maybe duo1) restarts the launcher when already in the same composition. We check the composition before checking if we really need to change. This happens between two of the dual screen postures, which causes a weird flicker when changing between these postures. 

The Animation can be seen down below:

https://github.com/user-attachments/assets/f4d952e5-ab2c-4b36-a359-e9fb95a31282


"What's the rationale behind the center green bar?"

- On duo 2 12L, the battery animation plays on device plugged events, and you can see this when the device is closed on the hinge. I thought it'd be neat to bring it over to this ROM.