### PR TITLE
Adding more functionality to the overlay for mainly Duo2

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -16,8 +16,9 @@
 	
 	<uses-permission android:name="android.permission.INTERACT_ACROSS_USERS"/>
 
-	<protected-broadcast android:name="com.thain.duo.LAUNCHER_RESTART" />
+    <uses-permission android:name="android.permission.DEVICE_POWER"/>
 
+	<protected-broadcast android:name="com.thain.duo.LAUNCHER_RESTART" />
 
 	<application android:name=".PostureProcessorApp"
 		android:directBootAware="true"

--- a/src/main/kotlin/com/thain/duo/PostureProcessorService.kt
+++ b/src/main/kotlin/com/thain/duo/PostureProcessorService.kt
@@ -500,7 +500,8 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
                 displayManager?.setDisplayOffsets(DEFAULT_DISPLAY, 0, 0)
                 setComposition(2)
                 
-                if (isPeakMode) peakModeOverlay.showOverlay(false)
+                //Always show overlay in this posture. 
+                if (isPeakMode && isDuo2) peakModeOverlay.showOverlay(false)
             }
 
             //The overlay refuses to show on these ones on Duo2. Forcing Dual Display.

--- a/src/main/kotlin/com/thain/duo/PostureProcessorService.kt
+++ b/src/main/kotlin/com/thain/duo/PostureProcessorService.kt
@@ -341,6 +341,7 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
         }
         peakModeOverlay.hideOverlay()
 
+        unregisterReceiver(pluggedInBroadcastReceiver) 
     }
 
     //Start sticky can start service without intent (aka null)

--- a/src/main/kotlin/com/thain/duo/PostureProcessorService.kt
+++ b/src/main/kotlin/com/thain/duo/PostureProcessorService.kt
@@ -69,7 +69,8 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
 
     private var postureLockVal: PostureLockSetting = PostureLockSetting.Dynamic
 
-    private var wirelessChargingIntentFilter: IntentFilter? = null
+    private var pluggedInIntentFilter: IntentFilter? = null
+    private var pluggedInBroadcastReceiver: PluggedInBroadcastReceiver? = null
 
     private lateinit var peakModeOverlay: PeakModeOverlay
     private var isPeakMode: Boolean = false
@@ -204,6 +205,15 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
         powerManager = applicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager
         connectHal()
         peakModeOverlay = PeakModeOverlay(this)
+
+        //On plugged in event, we want to re-show the overlay
+        pluggedInBroadcastReceiver = PluggedInBroadcastReceiver()
+        pluggedInIntentFilter = IntentFilter().also{intentFilter -> 
+            intentFilter.addAction("android.intent.action.ACTION_POWER_CONNECTED")
+            intentFilter.addAction("android.intent.action.ACTION_POWER_DISCONNECTED")
+            this.registerReceiver(pluggedInBroadcastReceiver, intentFilter)
+            Log.d(TAG, "Broadcast Receiver registered for plugged in event!")
+        }
 
     }
 
@@ -443,9 +453,21 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
         }
 
         var pt = postureType(newPosture.posture)
-        if (pt != 4 || pt != 5) {
-            peakModeOverlay.hideOverlay()
+
+        // Duo2 can see the screen from the side, hiding overlay when not in 3 either
+        if(isDuo2){
+            if (pt != 3 || pt != 4 || pt != 5){
+                peakModeOverlay.hideOverlay()
+            }
         }
+        else{
+            // For Duo1
+            if (pt != 4 || pt != 5) {
+                peakModeOverlay.hideOverlay()
+            }
+        }
+
+        
         when (pt) {
             0 -> {
                 // Should only restart the launcher if the composition has changed.
@@ -476,16 +498,18 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
                 systemWm?.clearForcedDisplaySize(DEFAULT_DISPLAY)
                 displayManager?.setDisplayOffsets(DEFAULT_DISPLAY, 0, 0)
                 setComposition(2)
+                
+                if (isPeakMode) peakModeOverlay.showOverlay(false)
             }
 
             //The overlay refuses to show on these ones on Duo2. Forcing Dual Display.
             4 -> {
                 setComposition(2)
-                if (isPeakMode) peakModeOverlay.showOverlay()
+                if (isPeakMode) peakModeOverlay.showOverlay(false)
             }
             5 -> {
                 setComposition(2)
-                if (isPeakMode) peakModeOverlay.showOverlay()
+                if (isPeakMode) peakModeOverlay.showOverlay(false)
             }
             else -> {
                 Log.d(TAG, "Unhandled posture");
@@ -689,6 +713,28 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
         }
 
         override fun onAccuracyChanged(sensor: Sensor, accuracy: Int) { }
+    }
+
+    inner class PluggedInBroadcastReceiver: BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent){     
+            if(action == "android.intent.action.ACTION_POWER_CONNECTED" || action == "android.intent.action.ACTION_POWER_DISCONNECTED" ){
+                // Get the current posture, check if it's either Closed and then show if it is one of these.
+                var pt = postureType(currentPosture.posture)
+
+                //Check if the posture is closed or are we a Duo2
+                if(!isDuo2 || pt != 3){
+                    return
+                }
+                
+                // There shouldn't be any reason for the device to be active during a closed position,
+                // This should show the overlay and then force the device to sleep after 5 seconds if we're in this position.
+                if(isPeakMode){
+                    peakModeOverlay.showOverlay(true)
+                    Log.d(TAG, "Received action ${action} and posture is closed, showing Overlay")
+                }
+                
+            }
+        }
     }
 
     public fun setPosture(postureMode: Int) {

--- a/src/main/kotlin/com/thain/duo/views/PeakModeOverlay.kt
+++ b/src/main/kotlin/com/thain/duo/views/PeakModeOverlay.kt
@@ -73,6 +73,15 @@ class PeakModeOverlay(private val context: Context) {
         val displayText = getTimeText(context)
         val dateText = getDateText(context)
 
+        // Cleanup overlay handlers
+        if(handler != null){
+            try{
+                runnable?.let { handler?.removeCallbacks(it) }
+            }catch (e: Exception){
+                e.printStackTrace()
+            }
+        }
+
         // Force the Overlay to cleanup
         hideOverlay(false)
         
@@ -130,15 +139,6 @@ class PeakModeOverlay(private val context: Context) {
                 windowManager.addView(overlayView, params)
             } catch (e: Exception) {
                 e.printStackTrace()
-            }
-
-            // Remove current handler callback and setup a new one if it exists
-            if(handler != null){
-                try{
-                    runnable?.let { handler?.removeCallbacks(it) }
-                }catch (e: Exception){
-                    e.printStackTrace()
-                }
             }
 
             // Setup new handler/runnable pair to hide the overlay after 5 seconds

--- a/src/main/kotlin/com/thain/duo/views/PeakModeOverlay.kt
+++ b/src/main/kotlin/com/thain/duo/views/PeakModeOverlay.kt
@@ -172,16 +172,11 @@ class PeakModeOverlay(private val context: Context) {
         }
     }
 
-    // Invoke the member from the PowerManager.java class. We need DEVICE_POWER permissions for this. 
-    // I'm fairly certain this will work as this app is System Signed.
-    // We're invoking cause this method is hidden.
+    //Shut screen off with generic reason.
     fun turnScreenOff(){
         val powerManager = this.getSystemService(Context.POWER_SERVICE) as PowerManager
         try {
-            powerManager.javaClass.getMethod(
-                "goToSleep",
-                *arrayOf<Class<*>?>(Long::class.javaPrimitiveType)
-            ).invoke(powerManager, SystemClock.uptimeMillis())
+            powerManager?.goToSleep(SystemClock.uptimeMillis())
         } catch (e: Exception) {
             e.printStackTrace()
         } 

--- a/src/main/kotlin/com/thain/duo/views/PeakModeOverlay.kt
+++ b/src/main/kotlin/com/thain/duo/views/PeakModeOverlay.kt
@@ -13,6 +13,10 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import android.view.animation.AccelerateDecelerateInterpolator
+import android.os.Handler
+import android.os.Looper
+import android.os.PowerManager
+import android.os.SystemClock
 
 class PeakModeOverlay(private val context: Context) {
 
@@ -20,9 +24,37 @@ class PeakModeOverlay(private val context: Context) {
         context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     private var overlayView: View? = null
 
+    private var handler: Handler? = null
+    private var runnable: Runnable? = null
+    private var fadeHandler: Handler? = null
+    private var fadeRunnable: Runnable? = null
+
     fun getBatteryPercentage(context: Context): Int {
         val batteryManager = context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
         return batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
+    }
+
+    fun getBatteryEmoji(context: Context): String {
+        val batteryManager = context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
+
+        val batteryStatus: Intent? = IntentFilter(Intent.ACTION_BATTERY_CHANGED).let { ifilter ->
+            context.registerReceiver(null, ifilter)
+        }
+        val status: Int = batteryStatus?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1
+
+        // Plug Emoji
+        if(batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY) == 100 && status == BatteryManager.BATTERY_STATUS_CHARGING){
+            return "\uD83D\uDD0C"
+        }
+
+        // Lightning symbol
+        if(status == BatteryManager.BATTERY_STATUS_CHARGING){
+            return "⚡"
+        }
+
+        //Default to Battery symbol
+        return "\uD83D\uDD0B"
+
     }
 
     fun getTimeText(context: Context): String {
@@ -37,9 +69,12 @@ class PeakModeOverlay(private val context: Context) {
         return "${formattedTime}"
     }
 
-    fun showOverlay() {  
+    fun showOverlay(sleepAfterShowingOverlay: Boolean) {  
         val displayText = getTimeText(context)
         val dateText = getDateText(context)
+
+        // Force the Overlay to cleanup
+        hideOverlay(false)
         
         // Inflate the overlay view
         overlayView = LayoutInflater.from(context).inflate(R.layout.peak_mode_overlay, null)
@@ -48,9 +83,12 @@ class PeakModeOverlay(private val context: Context) {
         // Duo2 had some issues with the overlay showing on only one screen, possibly due to the launcher not being restarted.
         val left_clock = overlayView?.findViewById<TextView>(R.id.left_clock)
         val left_battery = overlayView?.findViewById<TextView>(R.id.left_battery)
+        val left_hinge_clock = overlayView?.findViewById<TextView>(R.id.left_hinge_clock)
         val right_clock = overlayView?.findViewById<TextView>(R.id.right_clock)
         val right_battery = overlayView?.findViewById<TextView>(R.id.right_battery)
+        val right_hinge_clock = overlayView?.findViewById<TextView>(R.id.right_hinge_clock)
         val battery_background = overlayView?.findViewById<View>(R.id.battery_background)
+        val parent_view = overlayView?.findViewById<View>(R.id.parent_layout)
 
         var heightvar: Int = context.resources.displayMetrics.heightPixels
 
@@ -58,11 +96,21 @@ class PeakModeOverlay(private val context: Context) {
         
         battery_background?.animate()?.scaleY(heightToAnimateTo)?.setInterpolator(AccelerateDecelerateInterpolator())?.setDuration(3000);
         
-        if (left_clock != null && right_clock != null && left_battery != null && right_battery != null) {
+        if (left_clock != null && right_clock != null && left_battery != null && right_battery != null && right_hinge_clock != null && left_hinge_clock != null) {
+            var hinge_text = """${displayText} | ${getBatteryEmoji()}${getBatteryPercentage(context).toString()}%"""
+            var battery_text = """${dateText} | ${getBatteryEmoji()}${getBatteryPercentage(context).toString()}%"""
+
             left_clock.text = displayText
             right_clock.text = displayText
-            left_battery.text = """${dateText} | 🔋${getBatteryPercentage(context).toString()}%"""
-            right_battery.text = """${dateText} | 🔋${getBatteryPercentage(context).toString()}%"""
+            left_hinge_clock.text = hinge_text
+            right_hinge_clock.text = hinge_text
+            left_battery.text = battery_text
+            right_battery.text = battery_text
+        }
+        if(parent_view != null){
+            //Animate from 0 alpha
+            parent_view.alpha = 0f
+            animateParentOpacity(true)
         }
 
         // Define layout parameters for the overlay
@@ -76,23 +124,105 @@ class PeakModeOverlay(private val context: Context) {
                     WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED,
             PixelFormat.TRANSLUCENT
         )
+        
+        if(sleepAfterShowingOverlay){
+            try {
+                windowManager.addView(overlayView, params)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
 
-        try {
-            windowManager.addView(overlayView, params)
-        } catch (e: Exception) {
-            e.printStackTrace()
+            // Remove current handler callback and setup a new one if it exists
+            if(handler != null){
+                try{
+                    runnable?.let { handler?.removeCallbacks(it) }
+                }catch (e: Exception){
+                    e.printStackTrace()
+                }
+            }
+
+            // Setup new handler/runnable pair to hide the overlay after 5 seconds
+            handler = Handler(Looper.getMainLooper())
+            runnable = Runnable{
+                hideOverlay(true)
+                turnScreenOff()
+            }
+
+            handler!!.postDelayed(runnable!!, 5000)
         }
-
+        else{
+            //Add normally without explict hide timer.
+            try {
+                windowManager.addView(overlayView, params)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
     }
 
-    fun hideOverlay() {
-        if (overlayView != null) {
+    fun animateParentOpacity(show: Boolean){
+        var alphaToTarget = 1f
+        if(!show){
+            alphaToTarget = 0f
+        }
+
+        if(overlayView != null){
+            val parent_view = overlayView?.findViewById<View>(R.id.parent_layout)
+            parent_view?.animate()?.alpha(alphaToTarget)?.setInterpolator(AccelerateDecelerateInterpolator())?.setDuration(750)
+        }
+    }
+
+    // Invoke the member from the PowerManager.java class. We need DEVICE_POWER permissions for this. 
+    // I'm fairly certain this will work as this app is System Signed.
+    // We're invoking cause this method is hidden.
+    fun turnScreenOff(){
+        val powerManager = this.getSystemService(Context.POWER_SERVICE) as PowerManager
+        try {
+            powerManager.javaClass.getMethod(
+                "goToSleep",
+                *arrayOf<Class<*>?>(Long::class.javaPrimitiveType)
+            ).invoke(powerManager, SystemClock.uptimeMillis())
+        } catch (e: Exception) {
+            e.printStackTrace()
+        } 
+    }
+
+    fun hideOverlay(shouldAnimate: Boolean = true) {
+        // Destroy all Fade handlers
+        if(fadeHandler != null){
+            try{
+                fadeRunnable?.let { fadeHandler?.removeCallbacks(it) }
+            }catch (e: Exception){
+                e.printStackTrace()
+            }
+        }
+
+        if(!shouldAnimate){
             try {
-                windowManager.removeView(overlayView)
-                overlayView = null
+                if (overlayView != null) {
+                    windowManager.removeView(overlayView)
+                    overlayView = null
+                }
             } catch (e: Exception) {
             }
-        } 
+        
+            return
+        }
+
+        //Animate the overlay disappearing, should happen in 1 second.
+        animateParentOpacity(false)
+        fadeHandler = Handler(Looper.getMainLooper())
+        fadeRunnable = Runnable{
+            try {
+                if (overlayView != null) {
+                    windowManager.removeView(overlayView)
+                    overlayView = null
+                }
+            } catch (e: Exception) {
+            }
+        }
+
+        fadeHandler.postDelayed(fadeRunnable, 1000) 
     }
 
 }

--- a/src/main/res/layout/peak_mode_overlay.xml
+++ b/src/main/res/layout/peak_mode_overlay.xml
@@ -1,7 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/parent_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#AA000000"
+    android:background="#CC000000"
     android:padding="-50dp">
     <!-- Left clock rotated 90 degrees -->
     <View
@@ -38,6 +40,19 @@
         android:layout_marginLeft="0dp"
         android:gravity="center_vertical"/>
     <TextView
+        android:id="@+id/left_hinge_clock"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="13sp"
+        android:background="#55000000"
+        android:paddingHorizontal="10dp"
+        android:textColor="#FFFFFF"
+        android:rotation="270"
+        android:layout_alignParentLeft="true"
+        android:layout_marginLeft="488dp"
+        android:layout_centerVertical="true"
+        android:gravity="center_vertical"/>
+    <TextView
         android:id="@+id/left_battery"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
@@ -62,6 +77,20 @@
         android:layout_alignParentTop="true"
         android:layout_centerVertical="true"
         android:layout_marginRight="0dp"
+        android:gravity="center_vertical"/>
+
+    <TextView
+        android:id="@+id/right_hinge_clock"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="13sp"
+        android:background="#55000000"
+        android:paddingHorizontal="10dp"
+        android:textColor="#FFFFFF"
+        android:rotation="90"
+        android:layout_alignParentRight="true"
+        android:layout_marginRight="488dp"
+        android:layout_centerVertical="true"
         android:gravity="center_vertical"/>
 
     <TextView


### PR DESCRIPTION
Adding more functionality to the overlay for mainly Duo2

- Added a BroadcastReceiver on Plugged in/unplugged events to show overlay while plugged in only on Duo2
- Added function to change the battery emoji to a Lightning symbol/Plug symbol depending on the plugged in status
- Added a hinge clock for duo2
- Added alpha animation during hide overlay/show overlay events to smoothly show overlay instead of popping up on screen
- Added handlers to ensure only one timed event is occurring at a time.
- Added DEVICE_POWER permission as we are a system app that utilises the powermanager goToSleep calls often