### PR TITLE
Layout fixes to Overlay

### DIFF
--- a/src/main/kotlin/com/thain/duo/views/PeakModeOverlay.kt
+++ b/src/main/kotlin/com/thain/duo/views/PeakModeOverlay.kt
@@ -12,6 +12,8 @@ import android.os.BatteryManager
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import android.view.animation.Animation
+import android.view.animation.ScaleAnimation
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.os.Handler
 import android.os.Looper
@@ -71,6 +73,19 @@ class PeakModeOverlay(private val context: Context) {
         return "${formattedTime}"
     }
 
+    fun scaleView(v: View, startScale: Float, endScale: Float) {
+        val anim: Animation = ScaleAnimation(
+            1f, 1f,  // Start and end values for the X axis scaling
+            startScale, endScale,  // Start and end values for the Y axis scaling
+            Animation.RELATIVE_TO_SELF, 0f,  // Pivot point of X scaling
+            Animation.RELATIVE_TO_SELF, 1f
+        ) // Pivot point of Y scaling
+        anim.setFillAfter(true) // Needed to keep the result of the animation
+        anim.setDuration(1000)
+        anim.setInterpolator(AccelerateDecelerateInterpolator())
+        v.startAnimation(anim)
+    }
+
     fun showOverlay(sleepAfterShowingOverlay: Boolean) {  
         val displayText = getTimeText(context)
         val dateText = getDateText(context)
@@ -101,11 +116,7 @@ class PeakModeOverlay(private val context: Context) {
         val battery_background = overlayView?.findViewById<View>(R.id.battery_background)
         val parent_view = overlayView?.findViewById<View>(R.id.parent_layout)
 
-        var heightvar: Int = context.resources.displayMetrics.heightPixels
-
-        var heightToAnimateTo: Float = heightvar.toFloat() * (getBatteryPercentage(context) / 100f)    
-        
-        battery_background?.animate()?.scaleY(heightToAnimateTo)?.setInterpolator(AccelerateDecelerateInterpolator())?.setDuration(3000);
+        scaleView(battery_background!!, 0f, getBatteryPercentage(context).toFloat() / 100f)
         
         if (left_clock != null && right_clock != null && left_battery != null && right_battery != null && right_hinge_clock != null && left_hinge_clock != null) {
             var hinge_text = """${displayText} | ${getBatteryEmoji(context)}${getBatteryPercentage(context).toString()}%"""

--- a/src/main/res/layout/peak_mode_overlay.xml
+++ b/src/main/res/layout/peak_mode_overlay.xml
@@ -13,20 +13,37 @@
         android:layout_alignParentBottom="true"
         android:layout_height="1dp"/>
 
-    <View
-        android:layout_width="500dp"
-        android:layout_height="match_parent"
-        android:layout_alignParentLeft="true"
-        android:layout_marginLeft="25dp"
-        android:background="#000000" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-    <View
-        android:layout_width="500dp"
-        android:layout_height="match_parent"
-        android:layout_marginRight="25dp"
-        android:layout_alignParentRight="true"
-        android:background="#000000" />
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_alignParentStart="true"
+            android:layout_marginStart="25dp"
+            android:background="#000000"
+            app:layout_constraintDimensionRatio="w,1:1.5"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_marginEnd="25dp"
+            android:layout_alignParentEnd="true"
+            android:background="#000000"
+            app:layout_constraintDimensionRatio="w,1:1.5"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintRight_toRightOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
     <TextView
         android:id="@+id/left_clock"
         android:layout_width="wrap_content"

--- a/src/main/res/layout/peak_mode_overlay.xml
+++ b/src/main/res/layout/peak_mode_overlay.xml
@@ -11,7 +11,7 @@
         android:layout_width="match_parent"
         android:background="@drawable/expandable_square"
         android:layout_alignParentBottom="true"
-        android:layout_height="1dp"/>
+        android:layout_height="match_parent"/>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Fixes the following:

- Sets Battery Background to use whole parent, and then scales using function 
- Sets black squares to use Constraint view to make the width more consistent.


Hinge clock on Duo2 is still not constrained, so this is missing. Overlay also does not show on lockscreen, this seems to be because of the deprecated flag in the API, so we may need to create something to handle this case.