### PR TITLE
Checking if Hinge gap is disabled and positioning Hinge clock accordingly

### DIFF
--- a/src/main/kotlin/com/thain/duo/PostureProcessorService.kt
+++ b/src/main/kotlin/com/thain/duo/PostureProcessorService.kt
@@ -67,6 +67,7 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
 
     private var previousTablet: Boolean = true
     private var isDuo2: Boolean = false
+    private var isHingeDisabled: Boolean = false
 
     private var postureLockVal: PostureLockSetting = PostureLockSetting.Dynamic
 
@@ -150,7 +151,7 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
 
         val disableHingeVal = "1"
 
-        val disabledHinge = SystemProperties.get("persist.sys.phh.duo.disable_hinge", "0") == disableHingeVal
+        isHingeDisabled = SystemProperties.get("persist.sys.phh.duo.disable_hinge", "0") == disableHingeVal
 
         // Set the System setting in PHH to select from 3 Int vars, Dynamic (0), Right(1), Left(2)
         try{
@@ -159,7 +160,7 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
             postureLockVal = PostureLockSetting.Dynamic
         }
         
-        if (disabledHinge) {
+        if (isHingeDisabled) {
             PANEL_OFFSET = PANEL_X / 2
         }
 
@@ -502,17 +503,17 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
                 setComposition(2)
                 
                 //Always show overlay in this posture. 
-                if (isPeakMode && isDuo2) peakModeOverlay.showOverlay(false)
+                if (isPeakMode && isDuo2) peakModeOverlay.showOverlay(false, isHingeDisabled)
             }
 
             //The overlay refuses to show on these ones on Duo2. Forcing Dual Display.
             4 -> {
                 setComposition(2)
-                if (isPeakMode) peakModeOverlay.showOverlay(false)
+                if (isPeakMode) peakModeOverlay.showOverlay(false, isHingeDisabled)
             }
             5 -> {
                 setComposition(2)
-                if (isPeakMode) peakModeOverlay.showOverlay(false)
+                if (isPeakMode) peakModeOverlay.showOverlay(false, isHingeDisabled)
             }
             else -> {
                 Log.d(TAG, "Unhandled posture");
@@ -733,7 +734,7 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
                 // There shouldn't be any reason for the device to be active during a closed position,
                 // This should show the overlay and then force the device to sleep after 5 seconds if we're in this position.
                 if(isPeakMode){
-                    peakModeOverlay.showOverlay(true)
+                    peakModeOverlay.showOverlay(true, isHingeDisabled)
                     Log.d(TAG, "Received action ${action} and posture is closed, showing Overlay")
                 }
                 

--- a/src/main/kotlin/com/thain/duo/views/PeakModeOverlay.kt
+++ b/src/main/kotlin/com/thain/duo/views/PeakModeOverlay.kt
@@ -23,6 +23,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.view.ViewGroup
 import android.util.TypedValue
+import android.content.res.Resources
 
 class PeakModeOverlay(private val context: Context) {
 

--- a/src/main/kotlin/com/thain/duo/views/PeakModeOverlay.kt
+++ b/src/main/kotlin/com/thain/duo/views/PeakModeOverlay.kt
@@ -21,6 +21,8 @@ import android.os.PowerManager
 import android.os.SystemClock
 import android.content.Intent
 import android.content.IntentFilter
+import android.view.ViewGroup
+import android.util.TypedValue
 
 class PeakModeOverlay(private val context: Context) {
 
@@ -86,9 +88,15 @@ class PeakModeOverlay(private val context: Context) {
         v.startAnimation(anim)
     }
 
-    fun showOverlay(sleepAfterShowingOverlay: Boolean) {  
+    fun showOverlay(sleepAfterShowingOverlay: Boolean, hingeGapDisabled: Boolean == false) {  
         val displayText = getTimeText(context)
         val dateText = getDateText(context)
+        var hingeClockMargins = 40f // DP Val!
+
+        if(hingeGapDisabled)
+        {
+            hingeClockMargins = 15f // DP Val!
+        }
 
         // Cleanup overlay handlers
         if(handler != null){
@@ -128,6 +136,21 @@ class PeakModeOverlay(private val context: Context) {
             right_hinge_clock.text = hinge_text
             left_battery.text = battery_text
             right_battery.text = battery_text
+
+            // Convert DP to PX
+            val px = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                hingeClockMargins,
+                Resources.getSystem().displayMetrics
+            ).toInt()
+
+            // Apply to hinge
+            var leftHingeClockParams = left_hinge_clock.layoutParams as ViewGroup.MarginLayoutParams
+            leftHingeClockParams.marginEnd = px
+            left_hinge_clock.layoutParams = leftHingeClockParams
+            var rightHingeClockParams = right_hinge_clock.layoutParams as ViewGroup.MarginLayoutParams
+            rightHingeClockParams.marginStart = px
+            right_hinge_clock.layoutParams = rightHingeClockParams
         }
         if(parent_view != null){
             //Animate from 0 alpha

--- a/src/main/kotlin/com/thain/duo/views/PeakModeOverlay.kt
+++ b/src/main/kotlin/com/thain/duo/views/PeakModeOverlay.kt
@@ -88,7 +88,7 @@ class PeakModeOverlay(private val context: Context) {
         v.startAnimation(anim)
     }
 
-    fun showOverlay(sleepAfterShowingOverlay: Boolean, hingeGapDisabled: Boolean == false) {  
+    fun showOverlay(sleepAfterShowingOverlay: Boolean, hingeGapDisabled: Boolean = false) {  
         val displayText = getTimeText(context)
         val dateText = getDateText(context)
         var hingeClockMargins = 40f // DP Val!


### PR DESCRIPTION
#Checking if Hinge gap is disabled and positioning Hinge clock accordingly

- Prior to this fix, the clock would be pushed too far away from the hinge making it not visible.
- This should fix the issue, as we check the hinge if it's enabled and change the margin accordingly.
- made the hinge disabled check at the service level a class variable instead of a function local var.