### PR TITLE
Add User set 24 hour time, read from params to set clock position and enablement in main service

### DIFF
--- a/src/main/kotlin/com/thain/duo/PostureProcessorService.kt
+++ b/src/main/kotlin/com/thain/duo/PostureProcessorService.kt
@@ -76,6 +76,7 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
 
     private lateinit var peakModeOverlay: PeakModeOverlay
     private var isPeakMode: Boolean = false
+    private var isPeekModeEnabled: Boolean = true
 
     enum class PostureMode {
         Automatic,
@@ -149,9 +150,11 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
         HINGE_GAP = applicationContext.resources.getInteger(HINGE)
         PANEL_OFFSET = (PANEL_X + HINGE_GAP) / 2
 
-        val disableHingeVal = "1"
+        //Default value for when enabled
+        val defaultOn = "1"
 
-        isHingeDisabled = SystemProperties.get("persist.sys.phh.duo.disable_hinge", "0") == disableHingeVal
+        isHingeDisabled = SystemProperties.get("persist.sys.phh.duo.disable_hinge", "0") == defaultOn
+        isPeekModeEnabled = SystemProperties.get("persist.sys.phh.duo.peek_mode_enabled", "0") == defaultOn
 
         // Set the System setting in PHH to select from 3 Int vars, Dynamic (0), Right(1), Left(2)
         try{
@@ -503,17 +506,17 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
                 setComposition(2)
                 
                 //Always show overlay in this posture. 
-                if (isPeakMode && isDuo2) peakModeOverlay.showOverlay(false, isHingeDisabled)
+                if (isPeakMode && isDuo2 && isPeekModeEnabled) peakModeOverlay.showOverlay(false, isHingeDisabled)
             }
 
             //The overlay refuses to show on these ones on Duo2. Forcing Dual Display.
             4 -> {
                 setComposition(2)
-                if (isPeakMode) peakModeOverlay.showOverlay(false, isHingeDisabled)
+                if (isPeakMode && isPeekModeEnabled) peakModeOverlay.showOverlay(false, isHingeDisabled)
             }
             5 -> {
                 setComposition(2)
-                if (isPeakMode) peakModeOverlay.showOverlay(false, isHingeDisabled)
+                if (isPeakMode && isPeekModeEnabled) peakModeOverlay.showOverlay(false, isHingeDisabled)
             }
             else -> {
                 Log.d(TAG, "Unhandled posture");
@@ -733,7 +736,7 @@ public class PostureProcessorService : Service(), IHwBinder.DeathRecipient {
                 
                 // There shouldn't be any reason for the device to be active during a closed position,
                 // This should show the overlay and then force the device to sleep after 5 seconds if we're in this position.
-                if(isPeakMode){
+                if(isPeakMode && isPeekModeEnabled){
                     peakModeOverlay.showOverlay(true, isHingeDisabled)
                     Log.d(TAG, "Received action ${action} and posture is closed, showing Overlay")
                 }


### PR DESCRIPTION
- Uses user preference from System Time to figure out if they've enabled 24 hour time or not
- Adds reading of variable in treble app to figure out if the overlay should be shown or not.
- Adds option to move the hinge clock to top/bottom/center